### PR TITLE
Adjust styling to use simple page flow instead of block layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       #header p {
         margin-left: 2em;
         margin-right: 2em;
+        font-size: 8pt;
       }
 
       #main {
@@ -86,11 +87,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         display: inline-block;
         width: 256px;
         height: 256px;
-        margin: 0.5em;
+        margin: 2px;
         background: #333333;
         background-size: 100% 100%;
         position: relative;
-        border: 2px solid #444444;
+        border: 1px solid #444444;
       }
 
       .texture h2 {
@@ -173,135 +174,81 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       }
     </script>
   </head>
-  <body> 
 
-    <section id="header">
+  <body> 
       <h1>WebGL Texture Tester</h1>
 
-      <p>This page attempts to load one of every texture format supported by
-      WebGL (excluding videos). It is intended to quickly show which formats
-      your browser/device supports, and give browser vendors a quick way to
-      sanity-check their implementations.</p>
-
-      <p>It is expected that multiple textures on this page will fail to load
-      due to lack of hardware support. (For example: DXT formats are usually
-      only supported on Desktops while PVRTC is typically only available on
-      mobile devices with PowerVR chipsets.) Your hardware may support other
-      formats beyond what is shown here, but only the following formats have had
-      WebGL extensions specified for their use.</p>
-
-      <p>The source code used to load all of these formats can be found
-        <a href="https://github.com/toji/texture-tester/blob/master/js/webgl-texture-util.js">here</a>.
-      </p>
-    </section>
-
-    <section id="main">
-      <h1>Browser Native Formats (Uncompressed)</h1>
-
-      <div class="texture" x-src="textures/shannon.jpg" x-size-bytes="99488">
+      <span class="texture" x-src="textures/shannon.jpg" x-size-bytes="99488">
         <h2>JPEG</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon.png" x-size-bytes="463987">
+      <span class="texture" x-src="textures/shannon.png" x-size-bytes="463987">
         <h2>PNG</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon.gif" x-size-bytes="133577">
+      <span class="texture" x-src="textures/shannon.gif" x-size-bytes="133577">
         <h2>GIF</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon.bmp" x-size-bytes="786488">
+      <span class="texture" x-src="textures/shannon.bmp" x-size-bytes="786488">
         <h2>BMP</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon.webp" x-size-bytes="33378">
+      <span class="texture" x-src="textures/shannon.webp" x-size-bytes="33378">
         <h2>WEBP</h2>
-      </div>
+      </span>
 
-      <h1>
-        <a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/">
-          WEBGL_compressed_texture_s3tc
-        </a>
-      </h1>
-
-      <div class="texture" x-src="textures/shannon-dxt1.dds" x-size-bytes="174904">
+      <span class="texture" x-src="textures/shannon-dxt1.dds" x-size-bytes="174904">
         <h2>DXT1</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-dxt3.dds" x-size-bytes="262272">
+      <span class="texture" x-src="textures/shannon-dxt3.dds" x-size-bytes="262272">
         <h2>DXT3</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-dxt5.dds" x-size-bytes="349680">
+      <span class="texture" x-src="textures/shannon-dxt5.dds" x-size-bytes="349680">
         <h2>DXT5</h2>
-      </div>
+      </span>
 
-      <h1>
-        <a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/">
-          WEBGL_compressed_texture_s3tc
-        </a> with
-        <a href="https://code.google.com/p/crunch/">
-          Crunch Compression
-        </a>
-      </h1>
-
-      <div class="texture" x-src="textures/shannon-dxt1.crn" x-size-bytes="63186">
+      <span class="texture" x-src="textures/shannon-dxt1.crn" x-size-bytes="63186">
         <h2>DXT1 (Crunch)</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-dxt5.crn" x-size-bytes="71722">
+      <span class="texture" x-src="textures/shannon-dxt5.crn" x-size-bytes="71722">
         <h2>DXT5 (Crunch)</h2>
-      </div>
+      </span>
 
-      <h1>
-        <a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/">
-          WEBGL_compressed_texture_pvrtc
-        </a>
-      </h1>
-
-      <div class="texture" x-src="textures/shannon-pvrtc-2bpp-rgb.pvr" x-size-bytes="87555">
+      <span class="texture" x-src="textures/shannon-pvrtc-2bpp-rgb.pvr" x-size-bytes="87555">
         <h2>PVRTC (2BPP RGB)</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-pvrtc-2bpp-rgba.pvr" x-size-bytes="87555">
+      <span class="texture" x-src="textures/shannon-pvrtc-2bpp-rgba.pvr" x-size-bytes="87555">
         <h2>PVRTC (2BPP RGBA)</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-pvrtc-4bpp-rgb.pvr" x-size-bytes="174915">
+      <span class="texture" x-src="textures/shannon-pvrtc-4bpp-rgb.pvr" x-size-bytes="174915">
         <h2>PVRTC (4BPP RGB)</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-pvrtc-4bpp-rgba.pvr" x-size-bytes="174915">
+      <span class="texture" x-src="textures/shannon-pvrtc-4bpp-rgba.pvr" x-size-bytes="174915">
         <h2>PVRTC (4BPP RGBA)</h2>
-      </div>
+      </span>
 
-      <h1>
-        <a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/">
-          WEBGL_compressed_texture_atc
-        </a>
-      </h1>
-
-      <div class="texture" x-src="textures/shannon-atc-rgb.dds" x-size-bytes="131200">
+      <span class="texture" x-src="textures/shannon-atc-rgb.dds" x-size-bytes="131200">
         <h2>ATC (RGB)</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-atc-rgba-explicit.dds" x-size-bytes="262272">
+      <span class="texture" x-src="textures/shannon-atc-rgba-explicit.dds" x-size-bytes="262272">
         <h2>ATC (RGBA, Explicit)</h2>
-      </div>
+      </span>
 
-      <div class="texture" x-src="textures/shannon-atc-rgba-interpolated.dds" x-size-bytes="262272">
+      <span class="texture" x-src="textures/shannon-atc-rgba-interpolated.dds" x-size-bytes="262272">
         <h2>ATC (RGBA, Interpolated)</h2>
-      </div>
+      </span>
 
-      <h1>
-        <a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/">
-          WEBGL_compressed_texture_etc1
-        </a>
-      </h1>
-
-      <div class="texture" x-src="textures/shannon-etc1.pvr" x-size-bytes="174843">
+      <span class="texture" x-src="textures/shannon-etc1.pvr" x-size-bytes="174843">
         <h2>ETC1</h2>
-      </div>
+      </span>
     </section>
 
     <section id="footer">


### PR DESCRIPTION
This is a little bit less pretty, but it shows all the relevant information in popup over the tiles, and should fit on a wider variety of screens without having to jump through too many hoops.